### PR TITLE
Refactor view logic into Yelp model objects

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,34 +2,16 @@ require "open-uri"
 
 class SearchController < ApplicationController
   def index
+    yelp_service = YelpService.new
+
     if address
       begin
-        @response = search_by_address(address)
+        @businesses = yelp_service.search_by_address(address)
       rescue
-        @response = search_by_coordinates(coordinates)
+        @businesses = yelp_service.search_by_coordinates(coordinates)
       end
     else
-      @response = search_by_coordinates(coordinates)
+      @businesses = yelp_service.search_by_coordinates(coordinates)
     end
-  end
-
-  private
-
-  def search_by_address(address)
-    Yelp.client.search(
-      address,
-      {
-        limit: 10
-      }
-    )
-  end
-
-  def search_by_coordinates(coordinates)
-    Yelp.client.search_by_coordinates(
-      coordinates,
-      {
-        limit: 10
-      }
-    )
   end
 end

--- a/app/models/yelp_business.rb
+++ b/app/models/yelp_business.rb
@@ -1,0 +1,26 @@
+class YelpBusiness
+  BUSINESS_METHODS = [:image_url,
+                      :name,
+                      :location,
+                      :distance]
+
+  def initialize(burst_struct)
+    @burst_struct = burst_struct
+  end
+
+  BUSINESS_METHODS.each do |name|
+    define_method(name) { try_to_delegate_to_burst_struct(name) }
+  end
+
+  def location
+    YelpBusinessLocation.new(@burst_struct.location)
+  end
+
+  def try_to_delegate_to_burst_struct(name)
+    if @burst_struct.respond_to?(name)
+      @burst_struct.send(name)
+    else
+      nil
+    end
+  end
+end

--- a/app/models/yelp_business_location.rb
+++ b/app/models/yelp_business_location.rb
@@ -1,0 +1,35 @@
+class YelpBusinessLocation
+  LOCATION_METHODS = [:address,
+                      :city,
+                      :state_code,
+                      :postal_code,
+                      :neighborhoods]
+
+  def initialize(location)
+    @location = location
+  end
+
+  LOCATION_METHODS.each do |name|
+    define_method(name) { try_to_delegate_to_burst_struct(name) }
+  end
+
+  def coordinate
+    YelpLocationCoordinate.new(@location.coordinate)
+  end
+
+  def full_address
+    address.join(", ") if address
+  end
+
+  def neighborhoods_html
+    neighborhoods.join(", ").join("<br>").html_safe if neighborhoods
+  end
+
+  def try_to_delegate_to_burst_struct(name)
+    if @location.respond_to?(name)
+      @location.send(name)
+    else
+      nil
+    end
+  end
+end

--- a/app/models/yelp_location_coordinate.rb
+++ b/app/models/yelp_location_coordinate.rb
@@ -1,0 +1,20 @@
+class YelpLocationCoordinate
+  COORDINATE_METHODS = [:latitude,
+                      :longitude]
+
+  def initialize(coordinate)
+    @coordinate = coordinate
+  end
+
+  COORDINATE_METHODS.each do |name|
+    define_method(name) { try_to_delegate_to_burst_struct(name) }
+  end
+
+  def try_to_delegate_to_burst_struct(name)
+    if @coordinate.respond_to?(name)
+      @coordinate.send(name)
+    else
+      nil
+    end
+  end
+end

--- a/app/services/yelp_service.rb
+++ b/app/services/yelp_service.rb
@@ -1,0 +1,27 @@
+class YelpService
+  def search_by_address(address)
+    response = Yelp.client.search(
+      address,
+      {
+        limit: 10
+      }
+    )
+
+    response.businesses.map do |business|
+      YelpBusiness.new(business)
+    end
+  end
+
+  def search_by_coordinates(coordinates)
+    response = Yelp.client.search_by_coordinates(
+      coordinates,
+      {
+        limit: 10
+      }
+    )
+
+    response.businesses.map do |business|
+      YelpBusiness.new(business)
+    end
+  end
+end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -15,15 +15,13 @@
           <th>&nbsp;</th>
         </tr>
       </thead>
-<%# TODO: Refactor respond_to methods %>
-    <% @response.businesses.each_with_index do |business, index| %>
+    <% @businesses.each_with_index do |business, index| %>
       <tr>
-        <td><%= image_tag business.image_url if business.respond_to?(:image_url) %></td>
+        <td><%= image_tag business.image_url %></td>
         <td>
-          <%= business.name if business.respond_to?(:name) %><br>
-          <% if business.respond_to?(:location) %>
-            <%= business.location.address.join(", ") if business.location.respond_to?(:address) %><br>
-            <%= business.location.city if business.location.respond_to?(:city) %>, <%= business.location.state_code if business.location.respond_to?(:state_code) %> <%= business.location.postal_code if business.location.respond_to?(:postal_code) %><br>
+          <%= business.name %><br>
+            <%= business.location.full_address %><br>
+            <%= business.location.city %>, <%= business.location.state_code %> <%= business.location.postal_code %><br>
           <!-- Modal Start -->
           <div class="modal fade" id="directions-<%= index %>" tabindex="-1" role="dialog" aria-labelledby="directions-<%= index %> modal" aria-hidden="true">
             <div class="modal-dialog" role="document">
@@ -45,11 +43,10 @@
             </div>
           </div>
           <!-- Model End -->
-          <% end %>
         </td>
-        <td><%= business.location.neighborhoods.join("<br>").html_safe if business.respond_to?(:location) && business.location.respond_to?(:neighborhoods) %></td>
-        <td><%= ("%.2f" % (business.distance * 0.000621371) + " mi") if business.respond_to?(:distance) %></td>
-        <% walk_data = walk_score(business.location.address.join(", "), business.location.coordinate.latitude, business.location.coordinate.longitude) %>
+        <td><%= business.location.neighborhoods_html %></td>
+        <td><%= ("%.2f" % (business.distance * 0.000621371) + " mi") %></td>
+        <% walk_data = walk_score(business.location.full_address, business.location.coordinate.latitude, business.location.coordinate.longitude) %>
         <td><%= link_to "#{walk_data[:walkscore]}<br>#{walk_data[:description]}".html_safe, walk_data[:ws_link], target: "_blank" %></td>
         <td><button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#directions-<%= index %>">Directions</button></td>
       </tr>


### PR DESCRIPTION
Yelp API data comes back as a BustStruct object that has methods missing if data is not present.
Refactor checks on Yelp data from search index view to Yelp model objects:
- YelpBusiness
- YelpBusinessLocation
- YelpLocationCoordinate

Closes #17 
