### PR TITLE
Page performance #30

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,18 +12,12 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
 
 # Use Puma as the app server
 gem 'puma'
@@ -58,4 +52,3 @@ group :development do
   # Show performance metrics at /newrelic
   gem 'newrelic_rpm'
 end
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,15 +16,11 @@ class ApplicationController < ActionController::Base
   end
 
   def walk_score(address, latitude, longitude)
-    url = URI.parse("http://api.walkscore.com/score?format=json&lat=#{latitude}&lon=#{longitude}&wsapikey=#{ENV['walk_score_api_key']}")
-    JSON.parse(url.read, symbolize_names: true)
+    Rails.cache.fetch("walk_score", expires_in: 15.minutes) do
+      url = URI.parse("http://api.walkscore.com/score?format=json&lat=#{latitude}&lon=#{longitude}&wsapikey=#{ENV['walk_score_api_key']}")
+      JSON.parse(url.read, symbolize_names: true)
+    end
   end
-
-  # TODO: Remove if not used in final product
-  # def directions(origin, destination)
-  #   url = URI.parse("https://maps.googleapis.com/maps/api/directions/json?mode=walking&origin=#{origin}&destination=#{destination}&key=#{ENV['google_server_api_key']}")
-  #   JSON.parse(url.read, symbolize_names: true)
-  # end
 
   def directions_url(origin, destination)
     "https://www.google.com/maps/embed/v1/directions?mode=walking&origin=#{origin}&destination=#{destination}&key=#{ENV['google_browser_api_key']}"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,9 @@ class ApplicationController < ActionController::Base
   end
 
   def walk_score(address, latitude, longitude)
-    Rails.cache.fetch("walk_score", expires_in: 15.minutes) do
-      url = URI.parse("http://api.walkscore.com/score?format=json&lat=#{latitude}&lon=#{longitude}&wsapikey=#{ENV['walk_score_api_key']}")
+    Rails.cache.fetch("walk_score_#{address}_#{latitude}_#{longitude}",
+                      expires_in: 15.minutes) do
+      url = URI.parse("http://api.walkscore.com/score?format=json&address=#{address}&lat=#{latitude}&lon=#{longitude}&wsapikey=#{ENV['walk_score_api_key']}")
       JSON.parse(url.read, symbolize_names: true)
     end
   end

--- a/app/services/yelp_service.rb
+++ b/app/services/yelp_service.rb
@@ -1,27 +1,31 @@
 class YelpService
   def search_by_address(address)
-    response = Yelp.client.search(
-      address,
-      {
-        limit: 10
-      }
-    )
+    Rails.cache.fetch("yelp_search_by_address", expires_in: 15.minutes) do
+      response = Yelp.client.search(
+        address,
+        {
+          limit: 10
+        }
+      )
 
-    response.businesses.map do |business|
-      YelpBusiness.new(business)
+      response.businesses.map do |business|
+        YelpBusiness.new(business)
+      end
     end
   end
 
   def search_by_coordinates(coordinates)
-    response = Yelp.client.search_by_coordinates(
-      coordinates,
-      {
-        limit: 10
-      }
-    )
+    Rails.cache.fetch("yelp_search_by_coordinates", expires_in: 15.minutes) do
+      response = Yelp.client.search_by_coordinates(
+        coordinates,
+        {
+          limit: 10
+        }
+      )
 
-    response.businesses.map do |business|
-      YelpBusiness.new(business)
+      response.businesses.map do |business|
+        YelpBusiness.new(business)
+      end
     end
   end
 end

--- a/app/services/yelp_service.rb
+++ b/app/services/yelp_service.rb
@@ -1,6 +1,6 @@
 class YelpService
   def search_by_address(address)
-    Rails.cache.fetch("yelp_search_by_address", expires_in: 15.minutes) do
+    Rails.cache.fetch("yelp_search_#{address}", expires_in: 15.minutes) do
       response = Yelp.client.search(
         address,
         {
@@ -15,7 +15,7 @@ class YelpService
   end
 
   def search_by_coordinates(coordinates)
-    Rails.cache.fetch("yelp_search_by_coordinates", expires_in: 15.minutes) do
+    Rails.cache.fetch("yelp_search_#{coordinates}", expires_in: 15.minutes) do
       response = Yelp.client.search_by_coordinates(
         coordinates,
         {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,15 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Walk This Way</title>
-  <%= stylesheet_link_tag    "application", media: "all" %>
-  <%= javascript_include_tag "application" %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
-<%= render "/layouts/navbar" %>
+<% cache do %>
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <title>Walk This Way</title>
+    <%= stylesheet_link_tag    "application", media: "all" %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+  <%= render "/layouts/navbar" %>
+<% end %>
 <%= yield %>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,4 @@
-<% cache do %>
+<% cache("application_layout") do %>
   <!DOCTYPE html>
   <html>
   <head>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -42,7 +42,7 @@
               </div>
             </div>
           </div>
-          <!-- Model End -->
+          <!-- Modal End -->
         </td>
         <td><%= business.location.neighborhoods_html %></td>
         <td><%= ("%.2f" % (business.distance * 0.000621371) + " mi") %></td>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,16 +1,18 @@
-<!DOCTYPE html>
-<html id="landing-page">
-<head>
-  <title>Walk This Way</title>
-  <%= stylesheet_link_tag    "application", media: "all" %>
-  <%= javascript_include_tag "application" %>
-  <%= csrf_meta_tags %>
-</head>
-<body>
-  <%= render "/layouts/navbar" %>
-  <div class="center">
-    <h1>Walk This Way</h1>
-    <%= render "layouts/search" %>
+<% cache(controller: "welcome", action: "index") do %>
+  <!DOCTYPE html>
+  <html id="landing-page">
+  <head>
+    <title>Walk This Way</title>
+    <%= stylesheet_link_tag    "application", media: "all" %>
+    <%= javascript_include_tag "application" %>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+    <%= render "/layouts/navbar" %>
+    <div class="center">
+      <h1>Walk This Way</h1>
+<% end %>
+  <%= render "layouts/search" %>
   </div>
 </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Add low-level caching to improve repeat API call performance.
Add fragment caching to landing and search pages to improve repeat page call performance.
Closes #30 
